### PR TITLE
RS-16902: Use weights to compute denominator for percentages in sankey diagrams

### DIFF
--- a/R/sankeydiagram.R
+++ b/R/sankeydiagram.R
@@ -228,7 +228,7 @@ computeLinks <- function(data, weights, show.percentages = FALSE)
     links <- NULL
     counter <- 0
     n <- length(data)
-    tmp.total <- nrow(data)
+    tmp.total <- if (!is.null(weights)) Sum(weights) else nrow(data)
 
     for (i in 1:(n - 1)){
         x <- data[[i]]
@@ -305,7 +305,7 @@ categorizeData <- function(data, weights, max.categories, share.values,
     var.names <- names(data)
     n <- length(var.names)
     breaks <- NULL
-    .truncate <- function(labels, n) ifelse(nchar(labels) > label.max.length, 
+    .truncate <- function(labels, n) ifelse(nchar(labels) > label.max.length,
         paste0(substr(labels, 1, label.max.length), " ..."), labels)
 
     if (share.values)

--- a/R/sankeydiagram.R
+++ b/R/sankeydiagram.R
@@ -228,7 +228,7 @@ computeLinks <- function(data, weights, show.percentages = FALSE)
     links <- NULL
     counter <- 0
     n <- length(data)
-    tmp.total <- if (!is.null(weights)) Sum(weights) else nrow(data)
+    total <- if (!is.null(weights)) Sum(weights) else nrow(data)
 
     for (i in 1:(n - 1)){
         x <- data[[i]]
@@ -245,7 +245,7 @@ computeLinks <- function(data, weights, show.percentages = FALSE)
                 if (value > 0)
                 {
                     if (show.percentages)
-                        value <- value / tmp.total * 100
+                        value <- value / total * 100
 
                     column.node <- counter + n.x + i.y - 1
                     links <- rbind(links,c(row.node,column.node, value))

--- a/tests/testthat/test-sankeydiagram.R
+++ b/tests/testthat/test-sankeydiagram.R
@@ -83,7 +83,7 @@ test_that("Sankey diagrams: weights and filter",
                          hovertext.show.percentages = TRUE,
                          output.data.only = TRUE)
     expect_equal(sum(dat$links$value[dat$links$source == 0]),
-                 sum(weights[p$q1 == 1])/sum(weights))
+                 100 * sum(weights[p$q1 == 1])/sum(weights))
 
     data(colas, package = "flipExampleData")
     p <- colas[, c("d1", "d2")]

--- a/tests/testthat/test-sankeydiagram.R
+++ b/tests/testthat/test-sankeydiagram.R
@@ -68,28 +68,35 @@ expenses <- structure(list(Category = structure(c(4L, 2L, 1L, 2L, 1L, 3L,
 4972566, 2915644, 1762927))
 
 test_that("Sankey diagrams: weights and filter",
-          {
-              data(phone, package = "flipExampleData")
-              p <- phone[, c("q1", "q8", "q9", "q27")]
-              subset <- rep(TRUE, nrow(p))
-              subset[phone$q20h3 == "No"] <- FALSE
-              expect_error(print(SankeyDiagram(p, subset = subset)), NA)
-              weights <- sample(3, nrow(p), replace = TRUE)
-              expect_error(print(SankeyDiagram(p, weights = weights)), NA)
-              expect_error(print(SankeyDiagram(p, subset = subset, weights = weights)), NA)
+{
+    data(phone, package = "flipExampleData")
+    p <- phone[, c("q1", "q8", "q9", "q27")]
+    subset <- rep(TRUE, nrow(p))
+    subset[phone$q20h3 == "No"] <- FALSE
+    expect_error(print(SankeyDiagram(p, subset = subset)), NA)
+    weights <- sample(3, nrow(p), replace = TRUE)
+    expect_error(print(SankeyDiagram(p, weights = weights)), NA)
+    expect_error(print(SankeyDiagram(p, subset = subset, weights = weights)), NA)
 
-              data(colas, package = "flipExampleData")
-              p <- colas[, c("d1", "d2")]
-              subset <- rep(TRUE, nrow(p))
-              subset[colas$Q5_5_7 == "No"] <- FALSE
-              expect_error(print(SankeyDiagram(p, subset = subset)), NA)
-              weights <- rnorm(nrow(p))
-              weights[weights < 0] <- 0
-              expect_error(print(SankeyDiagram(p, weights = weights)), NA)
-              expect_error(print(SankeyDiagram(p, subset = subset, weights = weights)), NA)
+    # RS-16902: weights correctly used to compute percentages
+    dat <- SankeyDiagram(p, weights = weights,
+                         hovertext.show.percentages = TRUE,
+                         output.data.only = TRUE)
+    expect_equal(sum(dat$links$value[dat$links$source == 0]),
+                 sum(weights[p$q1 == 1])/sum(weights))
 
-              # Large weights
-              expect_error(SankeyDiagram(expenses, weights = attr(expenses, "weights")), NA)
+    data(colas, package = "flipExampleData")
+    p <- colas[, c("d1", "d2")]
+    subset <- rep(TRUE, nrow(p))
+    subset[colas$Q5_5_7 == "No"] <- FALSE
+    expect_error(print(SankeyDiagram(p, subset = subset)), NA)
+    weights <- rnorm(nrow(p))
+    weights[weights < 0] <- 0
+    expect_error(print(SankeyDiagram(p, weights = weights)), NA)
+    expect_error(print(SankeyDiagram(p, subset = subset, weights = weights)), NA)
+
+    # Large weights
+    expect_error(SankeyDiagram(expenses, weights = attr(expenses, "weights")), NA)
 })
 
 datNumeric <- structure(list(Length = structure(c(0.455, 0.35, 0.53, 0.44,


### PR DESCRIPTION
The tests seem to be failing due to an old plotly version? They were failing in the previous commit. Not sure how to address this. The feature is working fine in Displayr.