### PR TITLE
RS-18774: minor changes to fix snapshots

### DIFF
--- a/R/splinewithsimultaneousconfint.R
+++ b/R/splinewithsimultaneousconfint.R
@@ -169,6 +169,10 @@ SplineWithSimultaneousConfIntervals <- function(outcome,
     # Create plot
     plot.data <- pred$fit
     names(plot.data) <- pred$predictor
+    if (inherits(pred$predictor, "POSIXct")) {
+        cat("predictor is POSIXct")
+        names(plot.data) <- strftime(pred$predictor)
+    }
     cat("plot.data:\n")
     print(plot.data)
     pp <- Line(plot.data, colors = mean.color, line.thickness = mean.weight,

--- a/R/splinewithsimultaneousconfint.R
+++ b/R/splinewithsimultaneousconfint.R
@@ -180,7 +180,7 @@ SplineWithSimultaneousConfIntervals <- function(outcome,
              title = title, x.title = x.title, y.title = y.title,
              y.tick.format = y.tick.format, y.hovertext.format = y.hovertext.format,
              global.font.family = global.font.family, global.font.color = global.font.color,
-             title.font.size = title.font.size, x.grid.width = x.grid.width,
+             title.font.size = title.font.size, x.grid.width = x.grid.width, y.zero = y.zero,
              y.title.font.size = y.title.font.size, x.title.font.size = x.title.font.size,
              y.tick.font.size = y.tick.font.size, x.tick.font.size = x.tick.font.size,
              hovertext.font.size = hovertext.font.size, legend.show = FALSE, ...)

--- a/R/splinewithsimultaneousconfint.R
+++ b/R/splinewithsimultaneousconfint.R
@@ -169,13 +169,8 @@ SplineWithSimultaneousConfIntervals <- function(outcome,
 
     # Create plot
     plot.data <- pred$fit
-    names(plot.data) <- pred$predictor
-    if (inherits(pred$predictor, "POSIXct")) {
-        cat("predictor is POSIXct")
-        names(plot.data) <- strftime(pred$predictor)
-    }
-    cat("plot.data:\n")
-    print(plot.data)
+    names(plot.data) <- if (inherits(pred$predictor, "POSIXct")) strftime(pred$predictor)
+                        else pred$predictor
     pp <- Line(plot.data, colors = mean.color, line.thickness = mean.weight,
              title = title, x.title = x.title, y.title = y.title,
              y.tick.format = y.tick.format, y.hovertext.format = y.hovertext.format,
@@ -185,8 +180,6 @@ SplineWithSimultaneousConfIntervals <- function(outcome,
              y.tick.font.size = y.tick.font.size, x.tick.font.size = x.tick.font.size,
              hovertext.font.size = hovertext.font.size, legend.show = FALSE, ...)
 
-    cat("ribbon:\n")
-    print(pred$predictor)
     pp$htmlwidget <- add_ribbons(pp$htmlwidget, x = pred$predictor,
                      ymin = pred$lwrS, ymax = pred$uprS,
                      fillcolor = ci.color, line = list(color = "transparent"),
@@ -205,7 +198,6 @@ SplineWithSimultaneousConfIntervals <- function(outcome,
         for (i in unique(stackFits$ind))
         {
             ind <- which(stackFits$ind == i)
-            print(stackFits$predictor[ind][1:10])
             pp$htmlwidget <- add_lines(pp$htmlwidget, x = stackFits$predictor[ind], y = stackFits$values[ind],
                       line = list(color = draw.color, width = draw.weight),
                       hoverlabel = list(font = list(color = flipStandardCharts:::autoFontColor(draw.color))),

--- a/R/splinewithsimultaneousconfint.R
+++ b/R/splinewithsimultaneousconfint.R
@@ -48,6 +48,7 @@ SplineWithSimultaneousConfIntervals <- function(outcome,
                                                 y.tick.format = NULL,
                                                 x.grid.width = 1,
                                                 y.hovertext.format = ".1f",
+                                                y.zero = FALSE,
                                                 title = NULL,
                                                 x.title = NULL,
                                                 y.title = NULL,
@@ -186,7 +187,7 @@ SplineWithSimultaneousConfIntervals <- function(outcome,
 
     cat("ribbon:\n")
     print(pred$predictor)
-    pp$htmlwidget <- add_ribbons(pp$htmlwidget, x = names(plot.data),
+    pp$htmlwidget <- add_ribbons(pp$htmlwidget, x = pred$predictor,
                      ymin = pred$lwrS, ymax = pred$uprS,
                      fillcolor = ci.color, line = list(color = "transparent"),
                      text = sprintf(paste0("[%", y.hovertext.format, ", %", y.hovertext.format, "]"), pred$lwrS, pred$uprS),
@@ -205,7 +206,7 @@ SplineWithSimultaneousConfIntervals <- function(outcome,
         {
             ind <- which(stackFits$ind == i)
             print(stackFits$predictor[ind][1:10])
-            pp$htmlwidget <- add_lines(pp$htmlwidget, x = names(plot.data), y = stackFits$values[ind],
+            pp$htmlwidget <- add_lines(pp$htmlwidget, x = stackFits$predictor[ind], y = stackFits$values[ind],
                       line = list(color = draw.color, width = draw.weight),
                       hoverlabel = list(font = list(color = flipStandardCharts:::autoFontColor(draw.color))),
                       name = paste("Draw", i))

--- a/R/splinewithsimultaneousconfint.R
+++ b/R/splinewithsimultaneousconfint.R
@@ -169,6 +169,8 @@ SplineWithSimultaneousConfIntervals <- function(outcome,
     # Create plot
     plot.data <- pred$fit
     names(plot.data) <- pred$predictor
+    cat("plot.data:\n")
+    print(plot.data)
     pp <- Line(plot.data, colors = mean.color, line.thickness = mean.weight,
              title = title, x.title = x.title, y.title = y.title,
              y.tick.format = y.tick.format, y.hovertext.format = y.hovertext.format,
@@ -178,7 +180,9 @@ SplineWithSimultaneousConfIntervals <- function(outcome,
              y.tick.font.size = y.tick.font.size, x.tick.font.size = x.tick.font.size,
              hovertext.font.size = hovertext.font.size, legend.show = FALSE, ...)
 
-    pp$htmlwidget <- add_ribbons(pp$htmlwidget, x = pred$predictor,
+    cat("ribbon:\n")
+    print(pred$predictor)
+    pp$htmlwidget <- add_ribbons(pp$htmlwidget, x = names(plot.data),
                      ymin = pred$lwrS, ymax = pred$uprS,
                      fillcolor = ci.color, line = list(color = "transparent"),
                      text = sprintf(paste0("[%", y.hovertext.format, ", %", y.hovertext.format, "]"), pred$lwrS, pred$uprS),
@@ -196,7 +200,8 @@ SplineWithSimultaneousConfIntervals <- function(outcome,
         for (i in unique(stackFits$ind))
         {
             ind <- which(stackFits$ind == i)
-            pp$htmlwidget <- add_lines(pp$htmlwidget, x = stackFits$predictor[ind], y = stackFits$values[ind],
+            print(stackFits$predictor[ind][1:10])
+            pp$htmlwidget <- add_lines(pp$htmlwidget, x = names(plot.data), y = stackFits$values[ind],
                       line = list(color = draw.color, width = draw.weight),
                       hoverlabel = list(font = list(color = flipStandardCharts:::autoFontColor(draw.color))),
                       name = paste("Draw", i))

--- a/man/SplineWithSimultaneousConfIntervals.Rd
+++ b/man/SplineWithSimultaneousConfIntervals.Rd
@@ -21,6 +21,7 @@ SplineWithSimultaneousConfIntervals(
   y.tick.format = NULL,
   x.grid.width = 1,
   y.hovertext.format = ".1f",
+  y.zero = FALSE,
   title = NULL,
   x.title = NULL,
   y.title = NULL,
@@ -73,6 +74,8 @@ See https://github.com/d3/d3/blob/master/API.md#number-formats-d3-format}
 
 \item{y.hovertext.format}{A string representing a d3 formatting code
 See https://github.com/d3/d3/blob/master/API.md#number-formats-d3-format}
+
+\item{y.zero}{Whether the y-axis should include zero.}
 
 \item{title}{Character; chart title.}
 


### PR DESCRIPTION
* Change default `y.zero` to FALSE (this means that 0 is not forced on the y-axis) and matches behaviour of currrent spline plots
* Specify format of POSIXct vector being converted to string (as rownames of plot.data), to avoid problems with parsing dates